### PR TITLE
Read framebuffer dimentions directly from device. Fixes JB#46206 

### DIFF
--- a/vboxtouch/vboxtouch.cpp
+++ b/vboxtouch/vboxtouch.cpp
@@ -1,23 +1,32 @@
 /****************************************************************************
 **
+** Copyright (C) 2019 Open Mobile Platform LLC
+** Contact: https://community.omprussia.ru/open-source
+**
 ** Copyright (C) 2013 Jolla Ltd.
 ** Contact: Richard Braakman <richard.braakman@jollamobile.com>
 **
+** This file is part of the VBoxTouch plugin.
+**
+** $QT_BEGIN_LICENSE:LGPL$
 ** GNU Lesser General Public License Usage
 ** This file may be used under the terms of the GNU Lesser
 ** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+** Foundation and appearing in the file LICENSE.LGPL3 included
+** in the packaging of this file. Please review the following information
+** to ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-2.1.html.
 **
 ** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
+** Alternatively, this file may be used under the terms of the GNU General
+** Public License version 2.0 or (at your option) any later version approved
+** by the Free Software Foundation. The licenses are as published
+** by the Free Software Foundation and appearing in the file LICENSE.GPL2.1
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements
+** will be met: https://www.gnu.org/licenses/gpl-2.0.html.
+**
+** $QT_END_LICENSE$
 **
 ****************************************************************************/
 
@@ -80,6 +89,42 @@ const static vbox_mouse_status_request blank_mouse_status_request = {
 #define VBOXMOUSE_NEW_PROTOCOL 16
 // flags received:
 #define VBOXMOUSE_IS_ABSOLUTE 2
+// flags sent to framebuffer:
+#define FBIOGET_VSCREENINFO	0x4600
+
+struct ScreenGeometry
+{
+    QPoint uiOffset; // ui offset relative to framebuffer
+    QSize fbSize; // framebuffer size
+};
+
+ScreenGeometry getScreenGeometry()
+{
+    const QSize uiSize(QGuiApplication::primaryScreen()->size());
+    ScreenGeometry defaultGeometry = { QPoint(0, 0), uiSize };
+
+    /* Read framebuffer dimentions from device
+     * in some rare cases it may not be equal to QGuiApplication::primaryScreen()->geometry().size()
+     */
+    const QString fbDevice = "/dev/fb0";
+    const int fh = open(fbDevice.toLocal8Bit().constData(), O_RDONLY);
+    if (fh < 0) {
+        qWarning("vboxtouch: cannot open framebuffer %s: %s", qPrintable(fbDevice), strerror(errno));
+        return defaultGeometry;
+    }
+
+    uint32_t var[40];
+    const int err = ioctl(fh, FBIOGET_VSCREENINFO, &var);
+    if (err != 0) {
+        qWarning("vboxtouch: framebuffer ioctl error: %s", strerror(errno));
+        return defaultGeometry;
+    }
+    const int scale = qMax(1, qEnvironmentVariableIntValue("QT_QPA_EGLFS_SCALE"));
+    const QSize fbSize(var[0] * scale, var[1] * scale);
+    return uiSize == fbSize
+            ? defaultGeometry
+            : ScreenGeometry { QPoint(uiSize.width() - fbSize.width(), uiSize.height() - fbSize.height()), fbSize };
+}
 
 VirtualboxTouchScreenHandler::VirtualboxTouchScreenHandler(const QString &specification, QObject *parent)
     : QObject(parent), m_fd(-1), m_notifier(0), m_device(0), m_failures(0),
@@ -241,14 +286,16 @@ void VirtualboxTouchScreenHandler::reportTouch(Qt::TouchPointState state)
 
     qreal normal_x = (qreal) m_x / VBOX_COORD_MAX;
     qreal normal_y = (qreal) m_y / VBOX_COORD_MAX;
-    QRect screen = QGuiApplication::primaryScreen()->geometry();
+    ScreenGeometry screen = getScreenGeometry();
 
     tp.pressure = m_button ? 1 : 0;
     tp.state = state;
     tp.normalPosition = QPointF(normal_x, normal_y);
     tp.area = QRectF(0, 0, 4, 4);
-    tp.area.moveCenter(QPointF(normal_x * (screen.width() - 1),
-                               normal_y * (screen.height() - 1)));
+    // Assume UI (lipstick) bottom right corner always stay in bottom right corner of the framebuffer
+    // TODO: Create command line parameter corner "ui-corner-anchor": topleft, topright, bottomleft, bottomright, center
+    tp.area.moveCenter(QPointF(normal_x * (screen.fbSize.width() - 1),
+                               normal_y * (screen.fbSize.height() - 1) + screen.uiOffset.y()));
     tp.rawPositions.append(QPointF(m_x, m_y));
 
     QList<QWindowSystemInterface::TouchPoint> touchpoints;


### PR DESCRIPTION
In some rare cases mouse clicks not work properly in Sailfish OS emulator.

Reason:
It is possible that framebuffer dimentions may not be equal to QGuiApplication::primaryScreen()->geometry().size().

How to reproduce:
1. In Sailfish OS emulator virtual machine is set "CustomVideoMode1" to 600x600x32.
VBoxManage setextradata "Sailfish OS Emulator 3.0.3.9" "CustomVideoMode1" "600x600x32
2. In $HOME/SailfishOS/emulator/Sailfish OS Emulator 3.0.3.9/vmshare/65-emul-wayland-ui-scale.conf set:
QT_QPA_EGLFS_WIDTH=300
QT_QPA_EGLFS_HEIGHT=300
3. Start Sailfish OS emulator virtual machine.
4. In this case, mouse clicks will not work correctly.

Sergey Levin <s.levin@omprussia.ru>